### PR TITLE
feat(to_openstudio): Replace create_openstudio_object with to_openstuido

### DIFF
--- a/lib/from_honeybee/construction/opaque.rb
+++ b/lib/from_honeybee/construction/opaque.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       openstudio_construction = OpenStudio::Model::Construction.new(openstudio_model)
       openstudio_construction.setName(@hash[:name])
       

--- a/lib/from_honeybee/construction/shade.rb
+++ b/lib/from_honeybee/construction/shade.rb
@@ -51,8 +51,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
-
+    def to_openstudio(openstudio_model)
       os_construction = OpenStudio::Model::Construction.new(openstudio_model)
       os_construction.setName(@hash[:name])
       os_materials = OpenStudio::Model::MaterialVector.new

--- a/lib/from_honeybee/construction/window.rb
+++ b/lib/from_honeybee/construction/window.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       openstudio_construction = OpenStudio::Model::Construction.new(openstudio_model)
       openstudio_construction.setName(@hash[:name])
       

--- a/lib/from_honeybee/construction_set.rb
+++ b/lib/from_honeybee/construction_set.rb
@@ -54,7 +54,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       # create the constructionset object
       os_constr_set = OpenStudio::Model::DefaultConstructionSet.new(openstudio_model)
       os_constr_set.setName(@hash[:name])

--- a/lib/from_honeybee/geometry/aperture.rb
+++ b/lib/from_honeybee/geometry/aperture.rb
@@ -52,7 +52,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       # create the openstudio subsurface
       openstudio_vertices = OpenStudio::Point3dVector.new
       @hash[:geometry][:boundary].each do |vertex|

--- a/lib/from_honeybee/geometry/door.rb
+++ b/lib/from_honeybee/geometry/door.rb
@@ -52,7 +52,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       # create the OpenStudio door object
       openstudio_vertices = OpenStudio::Point3dVector.new
       @hash[:geometry][:boundary].each do |vertex|

--- a/lib/from_honeybee/geometry/face.rb
+++ b/lib/from_honeybee/geometry/face.rb
@@ -56,7 +56,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       # create the openstudio surface
       openstudio_vertices = OpenStudio::Point3dVector.new
       @hash[:geometry][:boundary].each do |vertex|

--- a/lib/from_honeybee/geometry/room.rb
+++ b/lib/from_honeybee/geometry/room.rb
@@ -64,7 +64,7 @@ module FromHoneybee
       nil 
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       # create the space and thermal zone
       os_space = OpenStudio::Model::Space.new(openstudio_model)
       os_space.setName(@hash[:name])

--- a/lib/from_honeybee/geometry/shade.rb
+++ b/lib/from_honeybee/geometry/shade.rb
@@ -52,7 +52,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       # create the openstudio shading surface
       openstudio_vertices = OpenStudio::Point3dVector.new
       @hash[:geometry][:boundary].each do |vertex|

--- a/lib/from_honeybee/hvac/ideal_air.rb
+++ b/lib/from_honeybee/hvac/ideal_air.rb
@@ -45,7 +45,7 @@ module FromHoneybee
       @@schema[:components][:schemas][:IdealAirSystemAbridged][:properties]
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       # create the ideal air system and set the name
       os_ideal_air = OpenStudio::Model::ZoneHVACIdealLoadsAirSystem.new(openstudio_model)
       os_ideal_air.setName(@hash[:name])

--- a/lib/from_honeybee/load/electric_equipment.rb
+++ b/lib/from_honeybee/load/electric_equipment.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
   
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_electric_equip_def = OpenStudio::Model::ElectricEquipmentDefinition.new(openstudio_model)
       os_electric_equip = OpenStudio::Model::ElectricEquipment.new(os_electric_equip_def)
       os_electric_equip_def.setName(@hash[:name])

--- a/lib/from_honeybee/load/gas_equipment.rb
+++ b/lib/from_honeybee/load/gas_equipment.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
   
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_gas_equip_def = OpenStudio::Model::GasEquipmentDefinition.new(openstudio_model)
       os_gas_equip = OpenStudio::Model::GasEquipment.new(os_gas_equip_def)
       os_gas_equip_def.setName(@hash[:name])

--- a/lib/from_honeybee/load/infiltration.rb
+++ b/lib/from_honeybee/load/infiltration.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
   
-    def create_openstudio_object(openstudio_model)       
+    def to_openstudio(openstudio_model)       
       os_infilt = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(openstudio_model)
       os_infilt.setName(@hash[:name])
 

--- a/lib/from_honeybee/load/lighting.rb
+++ b/lib/from_honeybee/load/lighting.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
   
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_lights_def = OpenStudio::Model::LightsDefinition.new(openstudio_model)
       os_lights = OpenStudio::Model::Lights.new(os_lights_def)
       os_lights_def.setName(@hash[:name])

--- a/lib/from_honeybee/load/people.rb
+++ b/lib/from_honeybee/load/people.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
   
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_people_def = OpenStudio::Model::PeopleDefinition.new(openstudio_model)
       os_people = OpenStudio::Model::People.new(os_people_def)
       os_people_def.setName(@hash[:name])

--- a/lib/from_honeybee/load/setpoint_humidistat.rb
+++ b/lib/from_honeybee/load/setpoint_humidistat.rb
@@ -45,7 +45,7 @@ module FromHoneybee
       @@schema[:components][:schemas][:SetpointAbridged][:properties]
     end
       
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_humidistat = OpenStudio::Model::ZoneControlHumidistat.new(openstudio_model)
 
       if @hash[:humidification_schedule]

--- a/lib/from_honeybee/load/setpoint_thermostat.rb
+++ b/lib/from_honeybee/load/setpoint_thermostat.rb
@@ -45,7 +45,7 @@ module FromHoneybee
       @@schema[:components][:schemas][:SetpointAbridged][:properties]
     end
   
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_thermostat = OpenStudio::Model::ThermostatSetpointDualSetpoint.new(openstudio_model)
 
       heat_sch = openstudio_model.getScheduleByName(@hash[:heating_schedule])

--- a/lib/from_honeybee/load/ventilation.rb
+++ b/lib/from_honeybee/load/ventilation.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
   
-    def create_openstudio_object(openstudio_model)       
+    def to_openstudio(openstudio_model)       
       os_vent = OpenStudio::Model::DesignSpecificationOutdoorAir.new(openstudio_model)
       os_vent.setName(@hash[:name])
 

--- a/lib/from_honeybee/material/opaque.rb
+++ b/lib/from_honeybee/material/opaque.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_opaque_mat = OpenStudio::Model::StandardOpaqueMaterial.new(openstudio_model)
       os_opaque_mat.setName(@hash[:name])
       os_opaque_mat.setThickness(@hash[:thickness])

--- a/lib/from_honeybee/material/opaque_no_mass.rb
+++ b/lib/from_honeybee/material/opaque_no_mass.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_nomass_mat = OpenStudio::Model::MasslessOpaqueMaterial.new(openstudio_model)
       os_nomass_mat.setName(@hash[:name])
       os_nomass_mat.setThermalResistance(@hash[:r_value])

--- a/lib/from_honeybee/material/window_blind.rb
+++ b/lib/from_honeybee/material/window_blind.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_blind = OpenStudio::Model::Blind.new(openstudio_model)
       os_blind.setName(@hash[:name])
       os_blind.setSlatOrientation(@hash[:slat_orientation])

--- a/lib/from_honeybee/material/window_gas.rb
+++ b/lib/from_honeybee/material/window_gas.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_window_gas = OpenStudio::Model::Gas.new(openstudio_model)
       os_window_gas.setName(@hash[:name])
 

--- a/lib/from_honeybee/material/window_gas_custom.rb
+++ b/lib/from_honeybee/material/window_gas_custom.rb
@@ -52,7 +52,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_gas_custom = OpenStudio::Model::Gas.new(openstudio_model)
       os_gas_custom.setName(@hash[:name])
       os_gas_custom.setGasType('Custom')

--- a/lib/from_honeybee/material/window_gas_mixture.rb
+++ b/lib/from_honeybee/material/window_gas_mixture.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       # create the gas mixture
       os_gas_mixture = OpenStudio::Model::GasMixture.new(openstudio_model)
       os_gas_mixture.setName(@hash[:name])

--- a/lib/from_honeybee/material/window_glazing.rb
+++ b/lib/from_honeybee/material/window_glazing.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_glazing = OpenStudio::Model::StandardGlazing.new(openstudio_model)
       os_glazing.setName(@hash[:name])
       

--- a/lib/from_honeybee/material/window_shade.rb
+++ b/lib/from_honeybee/material/window_shade.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_shade_mat = OpenStudio::Model::Shade.new(openstudio_model)
       os_shade_mat.setName(@hash[:name])
 

--- a/lib/from_honeybee/material/window_simpleglazsys.rb
+++ b/lib/from_honeybee/material/window_simpleglazsys.rb
@@ -51,7 +51,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_simple_glazing = OpenStudio::Model::SimpleGlazing.new(openstudio_model)
       os_simple_glazing.setName(@hash[:name])
       os_simple_glazing.setUFactor(@hash[:u_factor])

--- a/lib/from_honeybee/model_object.rb
+++ b/lib/from_honeybee/model_object.rb
@@ -97,39 +97,14 @@ module FromHoneybee
       end
     end
 
-    # convert ModelObject to an openstudio object
-    def to_openstudio(openstudio_model)
-      # return the object if we already have it
-      if @openstudio_object
-        if @openstudio_object.model == openstudio_model
-          return @openstudio_object
-        end
-      end
-
-      # TODO: uncomment this once valiation checks are optional
-      #@errors = validation_errors
-      @warnings = []
-      @openstudio_object = nil
-
-      # see if an equivalent object is already in the openstudio model
-      @openstudio_object = find_existing_openstudio_object(openstudio_model)
-      return @openstudio_object if @openstudio_object
-
-      # create and return the object
-      @openstudio_object = create_openstudio_object(openstudio_model)
-
-      @openstudio_object
-    end
-
     # find an equivalent existing object in the openstudio model, return nil if not found
-    def find_existing_openstudio_object(_openstudio_model)
-      # TODO: uncomment this once create_openstudio_object has been renamed to to_openstudio
-      # raise 'find_existing_openstudio_object is not yet implemented for this ModelObject.'
+    def find_existing_openstudio_object(openstudio_model)
+      raise 'find_existing_openstudio_object is not yet implemented for this ModelObject.'
     end
 
-    # create a new object in the openstudio model, return new object
-    def create_openstudio_object(_openstudio_model)
-      raise 'create_openstudio_object is not yet implemented for this ModelObject.'
+    # create a new object in the openstudio model and return it
+    def to_openstudio(openstudio_model)
+      raise 'to_openstudio is not yet implemented for this ModelObject.'
     end
   end # ModelObject
 end # FromHoneybee

--- a/lib/from_honeybee/program_type.rb
+++ b/lib/from_honeybee/program_type.rb
@@ -62,7 +62,7 @@ module FromHoneybee
       nil
     end
   
-    def create_openstudio_object(openstudio_model)    
+    def to_openstudio(openstudio_model)    
       openstudio_space_type = OpenStudio::Model::SpaceType.new(openstudio_model)
       openstudio_space_type.setName(@hash[:name])
 

--- a/lib/from_honeybee/schedule/fixed_interval.rb
+++ b/lib/from_honeybee/schedule/fixed_interval.rb
@@ -52,7 +52,7 @@ module FromHoneybee
       nil
     end
   
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       # create the new schedule
       os_fi_schedule = OpenStudio::Model::ScheduleFixedInterval.new(openstudio_model)
       os_fi_schedule.setName(@hash[:name])

--- a/lib/from_honeybee/schedule/ruleset.rb
+++ b/lib/from_honeybee/schedule/ruleset.rb
@@ -53,7 +53,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_sch_ruleset = OpenStudio::Model::ScheduleRuleset.new(openstudio_model)
       os_sch_ruleset.setName(@hash[:name])
 

--- a/lib/from_honeybee/schedule/type_limit.rb
+++ b/lib/from_honeybee/schedule/type_limit.rb
@@ -53,7 +53,7 @@ module FromHoneybee
       nil
     end
 
-    def create_openstudio_object(openstudio_model)
+    def to_openstudio(openstudio_model)
       os_type_limit = OpenStudio::Model::ScheduleTypeLimits.new(openstudio_model)
       os_type_limit.setName(@hash[:name])
 


### PR DESCRIPTION
This commit addressed the issues raised [here](https://github.com/ladybug-tools-in2/energy-model-measure/issues/33). Since we weren't using the the fancy lookups in the original to_openstudio method, I took it out in favor of using the more direct create_openstudio_object.  this will also make it more flexible in the future if we would like these to_openstudio methods to return an array of objects or accept more input arguments than the openstudio model.