### PR TITLE
feat(door): Allow Shades to be assigned to Doors

### DIFF
--- a/lib/from_honeybee/geometry/face.rb
+++ b/lib/from_honeybee/geometry/face.rb
@@ -32,7 +32,6 @@
 require 'from_honeybee/model_object'
 require 'from_honeybee/geometry/aperture'
 require 'from_honeybee/geometry/door'
-require 'from_honeybee/geometry/shade'
 
 require 'openstudio'
 


### PR DESCRIPTION
We recently decided that it was weird that people could not assign shades to Doors but they could to all other geometry objects as noted by [this change in the schema](https://github.com/ladybug-tools-in2/honeybee-schema/pull/24).  This commit updates the measure to support this new feature and I also put the code that creates shade groups into a function so that we have less copy/pasted code.