### PR TITLE
Fixes #77

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,4 @@ end
 
 # this code appears to be outdated and so it's commented out for now
 # simplecov has an unneccesary dependency on native json gem, use fork that does not require this
-# gem 'simplecov', github: 'NREL/simplecov'
+ gem 'simplecov', github: 'NREL/simplecov'

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,4 @@ end
 
 # this code appears to be outdated and so it's commented out for now
 # simplecov has an unneccesary dependency on native json gem, use fork that does not require this
- gem 'simplecov', github: 'NREL/simplecov'
+# gem 'simplecov', github: 'NREL/simplecov'

--- a/lib/from_honeybee/geometry/door.rb
+++ b/lib/from_honeybee/geometry/door.rb
@@ -84,13 +84,6 @@ module FromHoneybee
         end
       end
 
-      # assign the is_glass property
-      if @hash[:is_glass] == false
-        os_subsurface.setSubSurfaceType('Door')
-      else
-        os_subsurface.setSubSurfaceType('GlassDoor')
-      end
-
       os_subsurface
     end
   end # Door

--- a/lib/from_honeybee/geometry/face.rb
+++ b/lib/from_honeybee/geometry/face.rb
@@ -128,14 +128,16 @@ module FromHoneybee
           honeybee_door = Door.new(door)
           os_subsurface_door = honeybee_door.to_openstudio(openstudio_model)
           os_subsurface_door.setSurface(os_surface)
-          if door[:is_glass] == false
-            # set subsurface type
-            os_subsurface_door.setSubSurfaceType('Door')
-          elsif door[:is_glass] == true
+          if door[:is_glass] == true
             os_subsurface_door.setSubSurfaceType('GlassDoor')
-          elsif @hash[:face_type] == 'RoofCeiling' or @hash[:face_type] == 'Floor' && @hash[:boundary_condition][:type] == 'Outdoors'
+          elsif (@hash[:face_type] == 'RoofCeiling' or @hash[:face_type] == 'Floor') && @hash[:boundary_condition][:type] == 'Outdoors'
             os_subsurface_door.setSubSurfaceType('OverheadDoor')
+          elsif door[:is_glass] == false or door[:is_glass].nil?
+            os_subsurface_door.setSubSurfaceType('Door')
+            puts "3HELLO"
           end
+          puts "1HELLO = #{door}"
+          puts "2HELLO = #{os_subsurface_door}"
         end
       end
               

--- a/lib/from_honeybee/geometry/face.rb
+++ b/lib/from_honeybee/geometry/face.rb
@@ -125,12 +125,17 @@ module FromHoneybee
       # assign doors if they exist
       if @hash[:doors]
         @hash[:doors].each do |door|
-          door = Door.new(door)
-          os_subsurface_door = door.to_openstudio(openstudio_model)
-          if @hash[:face_type] == 'RoofCeiling' or @hash[:face_type] == 'Floor' && @hash[:boundary_condition][:type] == 'Outdoors'
-            os_subsurface_aperture.setSubSurfaceType('OverheadDoor')
-          end
+          honeybee_door = Door.new(door)
+          os_subsurface_door = honeybee_door.to_openstudio(openstudio_model)
           os_subsurface_door.setSurface(os_surface)
+          if door[:is_glass] == false
+            # set subsurface type
+            os_subsurface_door.setSubSurfaceType('Door')
+          elsif door[:is_glass] == true
+            os_subsurface_door.setSubSurfaceType('GlassDoor')
+          elsif @hash[:face_type] == 'RoofCeiling' or @hash[:face_type] == 'Floor' && @hash[:boundary_condition][:type] == 'Outdoors'
+            os_subsurface_door.setSubSurfaceType('OverheadDoor')
+          end
         end
       end
               

--- a/lib/from_honeybee/geometry/face.rb
+++ b/lib/from_honeybee/geometry/face.rb
@@ -128,16 +128,14 @@ module FromHoneybee
           honeybee_door = Door.new(door)
           os_subsurface_door = honeybee_door.to_openstudio(openstudio_model)
           os_subsurface_door.setSurface(os_surface)
-          if door[:is_glass] == true
-            os_subsurface_door.setSubSurfaceType('GlassDoor')
-          elsif (@hash[:face_type] == 'RoofCeiling' or @hash[:face_type] == 'Floor') && @hash[:boundary_condition][:type] == 'Outdoors'
-            os_subsurface_door.setSubSurfaceType('OverheadDoor')
-          elsif door[:is_glass] == false or door[:is_glass].nil?
+          if door[:is_glass] == false
+            # set subsurface type
             os_subsurface_door.setSubSurfaceType('Door')
-            puts "3HELLO"
+          elsif door[:is_glass] == true
+            os_subsurface_door.setSubSurfaceType('GlassDoor')
+          elsif @hash[:face_type] == 'RoofCeiling' or @hash[:face_type] == 'Floor' && @hash[:boundary_condition][:type] == 'Outdoors'
+            os_subsurface_door.setSubSurfaceType('OverheadDoor')
           end
-          puts "1HELLO = #{door}"
-          puts "2HELLO = #{os_subsurface_door}"
         end
       end
               

--- a/lib/from_honeybee/geometry/face.rb
+++ b/lib/from_honeybee/geometry/face.rb
@@ -128,13 +128,12 @@ module FromHoneybee
           honeybee_door = Door.new(door)
           os_subsurface_door = honeybee_door.to_openstudio(openstudio_model)
           os_subsurface_door.setSurface(os_surface)
-          if door[:is_glass] == false
-            # set subsurface type
-            os_subsurface_door.setSubSurfaceType('Door')
-          elsif door[:is_glass] == true
+          if door[:is_glass] == true
             os_subsurface_door.setSubSurfaceType('GlassDoor')
-          elsif @hash[:face_type] == 'RoofCeiling' or @hash[:face_type] == 'Floor' && @hash[:boundary_condition][:type] == 'Outdoors'
+          elsif (@hash[:face_type] == 'RoofCeiling' or @hash[:face_type] == 'Floor') && @hash[:boundary_condition][:type] == 'Outdoors'
             os_subsurface_door.setSubSurfaceType('OverheadDoor')
+          elsif door[:is_glass] == false or door[:is_glass].nil?
+            os_subsurface_door.setSubSurfaceType('Door')
           end
         end
       end

--- a/lib/measures/from_honeybee_model/tests/from_honeybee_model_test.rb
+++ b/lib/measures/from_honeybee_model/tests/from_honeybee_model_test.rb
@@ -109,6 +109,12 @@ class FromHoneybeeModel_Test < Minitest::Test
     apply_measure_to_model(__method__.to_s.gsub('test_',''),args, nil)
   end
 
+  def test_single_zone_office
+    args = {}
+    args['model_json'] = File.join(File.dirname(__FILE__) + "/../../../../spec/samples/model/model_complete_single_zone_office.json")
+    apply_measure_to_model(__method__.to_s.gsub('test_',''),args, nil)
+  end
+
   def test_detailed_loads
     args = {}
     args['model_json'] = File.join(File.dirname(__FILE__) + "/../../../../spec/samples/model/model_energy_detailed_loads.json")


### PR DESCRIPTION
Fixes bug while creating Doors. 
The `setSurface` property on the Door Subsurface was applied after the SurfaceType was set to "door" and it reset the SurfaceType to "Fixed Window" by default. 

The SurfaceType is specified after the setSurface now. 